### PR TITLE
Fix logout functionality by passing cookie headers to signOut

### DIFF
--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -111,8 +111,14 @@ export async function signIn(formData: FormData) {
  */
 export async function signOut() {
 	try {
+		const cookieStore = await cookies();
+		const requestHeaders = new Headers();
+		cookieStore.getAll().forEach((cookie) => {
+			requestHeaders.append("Cookie", `${cookie.name}=${cookie.value}`);
+		});
+		
 		await auth.api.signOut({
-			headers: new Headers(),
+			headers: requestHeaders,
 		});
 		return { success: true };
 	} catch (error) {


### PR DESCRIPTION
# Fix logout functionality by passing cookie headers to signOut

## Summary
Fixed a bug in the `signOut()` function where it was passing empty headers to Better Auth's signOut API, preventing proper session invalidation. The logout buttons in both desktop and mobile navigation were calling the function but users weren't actually being logged out.

**Root cause:** The `signOut()` function was passing `new Headers()` (empty) instead of the cookie headers required by Better Auth for session management.

**Solution:** Updated `signOut()` to construct and pass cookie headers using the same pattern already established in the `getCurrentUser()` function.

## Review & Testing Checklist for Human
- [ ] **Test end-to-end logout flow**: Sign in with a test account, then click logout in desktop navigation and verify user is logged out and redirected
- [ ] **Test mobile logout**: Repeat logout test using the mobile navigation menu
- [ ] **Verify session invalidation**: After logout, confirm user cannot access any routes that should require authentication (if any exist)

### Notes
⚠️ **Testing limitation**: I couldn't test this locally due to placeholder database credentials in `.env.local`. The fix follows the exact pattern used in `getCurrentUser()` which gives confidence it's correct, but end-to-end verification is needed.

**Link to Devin run**: https://app.devin.ai/sessions/ad6f3ba42ab64ce499f1443c4d8094a7  
**Requested by**: @mikbell