### PR TITLE
Fix authentication schema mapping and cookie name

### DIFF
--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -124,8 +124,7 @@ export async function signOut() {
 		});
 
 		// 2. PASSO FONDAMENTALE: Cancella manualmente il cookie di sessione utente dal browser.
-		// Assumo che Better-Auth usi 'auth_session' come nome.
-		cookiesStore.delete("better-auth.session");
+		cookiesStore.delete("auth_session");
 
 		// 3. Cancella il cookie guest per pulizia (già presente, ma bene ripeterlo)
 		cookiesStore.delete(GUEST_COOKIE_NAME);

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -10,7 +10,7 @@ export const auth = betterAuth({
 		provider: "pg",
 		schema: {
 			user: schema.user,
-			account: schema.session,
+			session: schema.session,
 			requireEmailVerification: false,
 		},
 	}),


### PR DESCRIPTION
# Fix authentication schema mapping and cookie name

## Summary
Fixes two critical bugs that broke the authentication system:

1. **Schema mapping bug**: Better Auth's `drizzleAdapter` was incorrectly configured with `account: schema.session` instead of `session: schema.session`. This prevented proper session creation and retrieval for email/password authentication.

2. **Cookie name mismatch**: The `signOut()` function was trying to delete a cookie named `"better-auth.session"` but the actual session cookie is configured as `"auth_session"` in the auth config.

The first bug was the primary cause of authentication failure - Better Auth couldn't properly manage user sessions with the wrong schema mapping.

## Review & Testing Checklist for Human
- [ ] **End-to-end auth flow**: Sign up with a new account, verify it works completely
- [ ] **Sign in functionality**: Test sign in with existing credentials  
- [ ] **Sign out functionality**: Verify logout properly clears session and redirects
- [ ] **Session persistence**: Confirm user remains logged in across page reloads
- [ ] **Database compatibility**: Check that session records are being created/read properly in the database

### Notes
⚠️ **Important**: These changes could not be tested locally due to placeholder database credentials in `.env.local`. The fixes are based on Better Auth documentation and configuration patterns, but require thorough manual testing to verify they resolve the authentication issues.

The schema mapping change aligns with Better Auth's drizzleAdapter requirements for email/password authentication, and the cookie name now matches the configured session cookie name.

**Requested by**: Michele (@mikbell)  
**Link to Devin run**: https://app.devin.ai/sessions/ad6f3ba42ab64ce499f1443c4d8094a7