### PR TITLE
Add account schema to Better Auth drizzle adapter

### DIFF
--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -11,6 +11,7 @@ export const auth = betterAuth({
 		schema: {
 			user: schema.user,
 			session: schema.session,
+			account: schema.account,
 			requireEmailVerification: false,
 		},
 	}),


### PR DESCRIPTION
# Add account schema to Better Auth drizzle adapter

## Summary
Fixes a regression introduced in PR #7 where Better Auth's drizzle adapter reports "The model 'account' was not found in the schema object." This occurred because the previous fix changed the schema mapping from `account: schema.session` to `session: schema.session`, but Better Auth requires BOTH the session and account models to be provided to the adapter, even when using email/password authentication.

This PR adds `account: schema.account` back to the drizzle adapter configuration alongside the existing session model.

## Review & Testing Checklist for Human
- [ ] **Test complete authentication flow**: Sign up, sign in, and sign out work without errors
- [ ] **Verify error resolution**: The "account model not found" error no longer appears in AuthForm
- [ ] **Check for new authentication errors**: No new Better Auth or database-related errors in console/logs

### Notes
- This fix was not tested locally due to missing database credentials in .env.local
- The account schema already exists in the codebase at `src/lib/db/schema/account.ts` and is properly exported
- Better Auth uses the account model for OAuth providers, but the adapter requires it to be present even for email/password auth

**Session**: https://app.devin.ai/sessions/ad6f3ba42ab64ce499f1443c4d8094a7  
**Requested by**: Michele Campanello (@mikbell)